### PR TITLE
TS18003 Build:No inputs were found in config file

### DIFF
--- a/MathJaxBlazor/MathJaxBlazor.csproj
+++ b/MathJaxBlazor/MathJaxBlazor.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/limefrogyank/MathJaxBlazor</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <Authors>L McPherson</Authors>
+	<IncludeContentInPack>false</IncludeContentInPack>
   </PropertyGroup>
 
 


### PR DESCRIPTION
This pull request fixes an build error that occurs after installing the latest version of the nuget package in a project.
Error fixed:
TS18003 Build:No inputs were found in config file 'C:/Users/<username>/.nuget/packages/mathjaxblazor/2.0.0/contentFiles/any/net6.0/tsconfig.json'. Specified 'include' paths were '["wwwroot/**/*"]' and 'exclude' paths were '["node_modules"]'.